### PR TITLE
Revert meta files of CompositeInstaller scripts for the compatibility

### DIFF
--- a/Source/Install/CompositeMonoInstaller.cs.meta
+++ b/Source/Install/CompositeMonoInstaller.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8fe93058050ff49a6a4efb3986e5d9ab
+guid: 5c0b026e5523f9c44acfea241a4f5ad6
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Source/Install/CompositeScriptableObjectInstaller.cs.meta
+++ b/Source/Install/CompositeScriptableObjectInstaller.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2ca8a0c76b705451c87b277891d093c4
+guid: 2f81b908d05150b4190f0ceb8456e280
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- `CompositeMonoInstaller` and `CompositeScriptableObjectInstaller` don't have the compatibility with those in Extenject
  - If migrating from Extenject, prefabs and ScriptableObjects will be missing references because "guid"s in meta files have been changed
  - It would make hard to migrate from Extenject to UniDi

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `CompositeMonoInstaller` and `CompositeScriptableObjectInstaller` have the compatibility with those in Extenject

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


On which Unity version has this been tested?
--------------------------------------------
- [x] 2021.2

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

Could you confirm this PR?

---
@Mathijs-Bakker 

I have a question.
Why have you changed meta files of scripts?

It seems that tests with MonoBehaviour have been failed because prefabs for tests have been missing references.

Thanks,