### PR TITLE
Fix missing execution orders in meta files

### DIFF
--- a/Source/Install/Contexts/SceneContext.cs.meta
+++ b/Source/Install/Contexts/SceneContext.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -9999
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Source/Runtime/GuiRenderer.cs.meta
+++ b/Source/Runtime/GuiRenderer.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -9995
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Source/Runtime/Kernels/DefaultGameObjectKernel.cs.meta
+++ b/Source/Runtime/Kernels/DefaultGameObjectKernel.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -9996
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Source/Runtime/Kernels/ProjectKernel.cs.meta
+++ b/Source/Runtime/Kernels/ProjectKernel.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -9998
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Source/Runtime/Kernels/SceneKernel.cs.meta
+++ b/Source/Runtime/Kernels/SceneKernel.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -9997
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Source/Util/UniDiStateMachineBehaviourAutoInjecter.cs.meta
+++ b/Source/Util/UniDiStateMachineBehaviourAutoInjecter.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -9991
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
It looks like the execution orders of the different Context/Kernel classes were zeroed out when this repo was made. This was causing objects to be initialized out of order in the project I am working on.

This pull request restores the execution orders back to what they were in the Extenject/Zenject repos.

As an alternative to changing the execution orders in the meta files, there is the [DefaultExecutionOrder] attribute. I'm not sure when this was added to Unity and it's for some reason undocumented so I have not used it in this pull request.

The execution orders in the Extenject/Zenject repos look like this:
![image](https://user-images.githubusercontent.com/42710136/167759928-2d5ecd80-06d4-4471-8698-dbec357f1fee.png)

Here is how the execution orders look in UniDi after my changes:
![image](https://user-images.githubusercontent.com/42710136/167761000-c9d93ef7-5d0a-48f0-bb74-8a0eee7d4190.png)

Files referenced:
https://github.com/Mathijs-Bakker/Extenject/blob/master/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/SceneContext.cs.meta
https://github.com/Mathijs-Bakker/Extenject/blob/master/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/ProjectKernel.cs.meta
https://github.com/Mathijs-Bakker/Extenject/blob/master/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/SceneKernel.cs.meta
https://github.com/Mathijs-Bakker/Extenject/blob/master/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/DefaultGameObjectKernel.cs.meta
https://github.com/Mathijs-Bakker/Extenject/blob/master/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Managers/GuiRenderer.cs.meta
https://github.com/Mathijs-Bakker/Extenject/blob/master/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/ZenjectStateMachineBehaviourAutoInjecter.cs.meta